### PR TITLE
feat(ui): implement Sign In screen with password toggle and validatio…

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-06-17T22:04:21.133503Z">
+        <DropdownSelection timestamp="2025-06-18T19:14:50.944317Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/remziakgoz/.android/avd/Pixel_6a.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/remziakgoz/.android/avd/Pixel_4.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/java/com/remziakgoz/coffeepomodoro/MainActivity.kt
+++ b/app/src/main/java/com/remziakgoz/coffeepomodoro/MainActivity.kt
@@ -7,7 +7,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
-import com.remziakgoz.coffeepomodoro.presentation.screens.WelcomeScreen
+import com.remziakgoz.coffeepomodoro.presentation.screens.SignInScreen
 import com.remziakgoz.coffeepomodoro.presentation.ui.theme.CoffePomodroTheme
 
 class MainActivity : ComponentActivity() {
@@ -17,7 +17,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             CoffePomodroTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    WelcomeScreen(modifier = Modifier, innerPadding)
+                    SignInScreen(modifier = Modifier, innerPadding)
                 }
             }
         }

--- a/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/screens/SignInScreen.kt
+++ b/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/screens/SignInScreen.kt
@@ -1,0 +1,156 @@
+package com.remziakgoz.coffeepomodoro.presentation.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.remziakgoz.coffeepomodoro.R
+import com.remziakgoz.coffeepomodoro.presentation.ui.theme.Pacifico
+import com.remziakgoz.coffeepomodoro.presentation.ui.theme.signInColor
+import org.w3c.dom.Text
+
+@Composable
+fun SignInScreen(modifier: Modifier = Modifier, innerPadding: PaddingValues) {
+
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var passwordVisible by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+    ) {
+
+        Image(
+            painter = painterResource(R.drawable.welcome),
+            contentDescription = "Sign In Background Image",
+            modifier = modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop
+
+        )
+
+        Column(
+            modifier = modifier
+                .align(Alignment.BottomStart)
+                .padding(horizontal = 24.dp, vertical = 32.dp)
+        ) {
+            Text(
+                text = "Sign in",
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Start,
+                style = Pacifico,
+                fontSize = 40.sp
+            )
+
+            Spacer(modifier = modifier.padding(5.dp))
+
+            TextField(
+                value = email,
+                onValueChange = { email = it },
+                label = { Text("Email") },
+                leadingIcon = { Icon(painterResource(R.drawable.mailicon), contentDescription = "Email Icon") },
+                placeholder = { Text("Please enter your email") },
+                singleLine = true,
+                modifier = modifier.fillMaxWidth(),
+                colors = TextFieldDefaults.colors(
+                    focusedIndicatorColor = signInColor,
+                    unfocusedIndicatorColor = Color(0xFFFFCC80),
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent
+                )
+            )
+
+            Spacer(modifier = modifier.padding(5.dp))
+
+            TextField(
+                value = password,
+                onValueChange = { password = it },
+                label = { Text("Password") },
+                leadingIcon = { Icon(painterResource(R.drawable.passwordicon), contentDescription = "Password Icon") },
+                trailingIcon = {
+                    val visibilityIcon = if(passwordVisible)
+                        R.drawable.passwordhideicon
+                    else
+                        R.drawable.passwordshowicon
+                    IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                        Icon(painter = painterResource(id = visibilityIcon), contentDescription = "Password Toggle")
+                    }
+                },
+                visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                placeholder = { Text("Please enter your password") },
+                singleLine = true,
+                modifier = modifier.fillMaxWidth(),
+                colors = TextFieldDefaults.colors(
+                    focusedIndicatorColor = signInColor,
+                    unfocusedIndicatorColor = Color(0xFFFFCC80),
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent
+                )
+
+            )
+
+            Spacer(modifier = modifier.padding(32.dp))
+
+            Button(onClick = { /*TODO*/ }, modifier = modifier.fillMaxWidth(), colors = ButtonDefaults.buttonColors(
+                containerColor = signInColor,
+                contentColor = Color.White
+            )) {
+                Text(
+                    text = "Login",
+                    color = Color.White,
+                    fontSize = 18.sp,
+                    style = Pacifico
+                )
+            }
+            Spacer(modifier = modifier.padding(5.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+
+                Text("Don't have an Account?", color = Color.Black.copy(alpha = 0.4f), fontSize = 14.sp)
+                TextButton(onClick = { /*TODO*/ }) {
+                    Text("Sign Up", color = signInColor, fontSize = 14.sp)
+                }
+
+
+            }
+
+        }
+
+    }
+}

--- a/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/screens/WelcomeScreen.kt
+++ b/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/screens/WelcomeScreen.kt
@@ -38,7 +38,7 @@ fun WelcomeScreen(modifier: Modifier, innerPadding: PaddingValues) {
 
         Image(
             painter = painterResource(id = R.drawable.welcome),
-            contentDescription = "Welcome Image",
+            contentDescription = "Welcome Background Image",
             modifier = Modifier.fillMaxSize(),
             contentScale = ContentScale.Crop
         )

--- a/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/ui/theme/Color.kt
+++ b/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/ui/theme/Color.kt
@@ -18,3 +18,5 @@ val CoffeeTertiaryDark = Color(0xFF2B1E17)
 val CoffeeSurfaceDark = Color(0xFF14110F)
 val CoffeeOnPrimaryDark = Color(0xFFD8CAB1)
 val CoffeeErrorDark = Color(0xFFB84A39)
+
+val signInColor = Color(0xFFFFCFA9)

--- a/app/src/main/res/drawable/mailicon.xml
+++ b/app/src/main/res/drawable/mailicon.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M4.667,5.667L6.628,6.826C7.771,7.502 8.229,7.502 9.372,6.826L11.333,5.667"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#616161"
+      android:strokeLineCap="round"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M1.344,8.984C1.387,11.027 1.409,12.049 2.163,12.806C2.917,13.563 3.967,13.59 6.066,13.642C7.36,13.675 8.64,13.675 9.934,13.642C12.033,13.59 13.083,13.563 13.837,12.806C14.591,12.049 14.613,11.027 14.656,8.984C14.67,8.327 14.67,7.673 14.656,7.016C14.613,4.973 14.591,3.951 13.837,3.194C13.083,2.437 12.033,2.41 9.934,2.358C8.64,2.325 7.36,2.325 6.066,2.358C3.967,2.41 2.917,2.437 2.163,3.194C1.409,3.951 1.387,4.973 1.344,7.016C1.33,7.673 1.33,8.327 1.344,8.984Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#616161"/>
+</vector>

--- a/app/src/main/res/drawable/passwordhideicon.xml
+++ b/app/src/main/res/drawable/passwordhideicon.xml
@@ -1,0 +1,26 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M12.959,10.293C13.576,9.681 14.052,9.073 14.363,8.637C14.565,8.352 14.667,8.21 14.667,8C14.667,7.79 14.565,7.648 14.363,7.363C13.452,6.086 11.126,3.333 8,3.333C7.395,3.333 6.82,3.436 6.279,3.612M4.498,4.498C3.154,5.405 2.161,6.628 1.637,7.363C1.435,7.648 1.333,7.79 1.333,8C1.333,8.21 1.435,8.352 1.637,8.637C2.548,9.914 4.874,12.667 8,12.667C9.327,12.667 10.51,12.17 11.502,11.502"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M6.572,6.667C6.219,7.02 6,7.508 6,8.047C6,9.126 6.874,10 7.953,10C8.492,10 8.98,9.781 9.333,9.428"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M2,2L14,14"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/passwordicon.xml
+++ b/app/src/main/res/drawable/passwordicon.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M14.667,8C14.667,11.682 11.682,14.667 8,14.667C4.318,14.667 1.333,11.682 1.333,8C1.333,4.318 4.318,1.333 8,1.333C11.682,1.333 14.667,4.318 14.667,8Z"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M8,8.667C8.736,8.667 9.333,8.07 9.333,7.333C9.333,6.597 8.736,6 8,6C7.264,6 6.667,6.597 6.667,7.333C6.667,8.07 7.264,8.667 8,8.667ZM8,8.667V10.667"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/passwordshowicon.xml
+++ b/app/src/main/res/drawable/passwordshowicon.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M14.363,7.363C14.565,7.648 14.667,7.79 14.667,8C14.667,8.21 14.565,8.353 14.363,8.637C13.452,9.914 11.126,12.667 8,12.667C4.874,12.667 2.548,9.914 1.637,8.637C1.435,8.353 1.333,8.21 1.333,8C1.333,7.79 1.435,7.648 1.637,7.363C2.548,6.086 4.874,3.333 8,3.333C11.126,3.333 13.452,6.086 14.363,7.363Z"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M10,8C10,6.895 9.105,6 8,6C6.895,6 6,6.895 6,8C6,9.105 6.895,10 8,10C9.105,10 10,9.105 10,8Z"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"/>
+</vector>


### PR DESCRIPTION
This PR implements the Sign In screen UI including:

- Email and password input fields
- Password visibility toggle
- Custom icons and placeholder text
- Themed button with Pacifico font
- Bottom "Don't have an account? Sign Up" section with clickable action

No backend logic or validation is included — this is strictly a UI implementation based on the Figma design.
